### PR TITLE
Harden basic authentication handling

### DIFF
--- a/NBXplorer.Tests/BasicAuthenticationHandlerTests.cs
+++ b/NBXplorer.Tests/BasicAuthenticationHandlerTests.cs
@@ -45,11 +45,12 @@ namespace NBXplorer.Tests
 		public async Task ChallengeAdvertisesBasicAuthentication()
 		{
 			var context = CreateContext();
+			context.Response.Headers.WWWAuthenticate = "Bearer";
 
 			await context.ChallengeAsync("Basic");
 
 			Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
-			Assert.Equal("Basic", context.Response.Headers.WWWAuthenticate);
+			Assert.Equal(new[] { "Bearer", "Basic" }, context.Response.Headers.WWWAuthenticate);
 		}
 
 		private static async Task<AuthenticateResult> Authenticate(string header)

--- a/NBXplorer.Tests/BasicAuthenticationHandlerTests.cs
+++ b/NBXplorer.Tests/BasicAuthenticationHandlerTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NBXplorer.Authentication;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class BasicAuthenticationHandlerTests
+	{
+		[Theory]
+		[InlineData("Basic !!!")]
+		[InlineData("Basic bm9jb2xvbg==")]
+		[InlineData("BasicWhatever dXNlcjpwYXNzd29yZA==")]
+		public async Task MalformedHeadersFailWithoutThrowing(string header)
+		{
+			var result = await Authenticate(header);
+
+			Assert.False(result.Succeeded);
+			Assert.NotNull(result.Failure);
+		}
+
+		[Fact]
+		public async Task CredentialsAreCaseSensitive()
+		{
+			var result = await Authenticate(CreateHeader("user", "PASSWORD"));
+
+			Assert.False(result.Succeeded);
+		}
+
+		[Fact]
+		public async Task ValidCredentialsAuthenticateWithConfiguredScheme()
+		{
+			var result = await Authenticate(CreateHeader("user", "password"));
+
+			Assert.True(result.Succeeded);
+			Assert.Equal("Basic", result.Ticket.AuthenticationScheme);
+			Assert.Equal("Basic", result.Principal.Identity.AuthenticationType);
+		}
+
+		[Fact]
+		public async Task ChallengeAdvertisesBasicAuthentication()
+		{
+			var context = CreateContext();
+
+			await context.ChallengeAsync("Basic");
+
+			Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+			Assert.Equal("Basic", context.Response.Headers.WWWAuthenticate);
+		}
+
+		private static async Task<AuthenticateResult> Authenticate(string header)
+		{
+			var context = CreateContext();
+			context.Request.Headers.Authorization = header;
+			return await context.AuthenticateAsync("Basic");
+		}
+
+		private static DefaultHttpContext CreateContext()
+		{
+			var services = new ServiceCollection()
+				.AddLogging()
+				.AddAuthentication("Basic")
+				.AddScheme<BasicAuthenticationOptions, BasicAuthenticationHandler>("Basic", options =>
+				{
+					options.Username = "user";
+					options.Password = "password";
+				})
+				.Services
+				.BuildServiceProvider();
+
+			return new DefaultHttpContext { RequestServices = services };
+		}
+
+		private static string CreateHeader(string username, string password)
+		{
+			return "Basic " + Convert.ToBase64String(Encoding.Latin1.GetBytes($"{username}:{password}"));
+		}
+	}
+}

--- a/NBXplorer/Authentication/BasicAuthenticationHandler.cs
+++ b/NBXplorer/Authentication/BasicAuthenticationHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -64,7 +65,7 @@ namespace NBXplorer.Authentication
 
 		protected override Task HandleChallengeAsync(AuthenticationProperties properties)
 		{
-			Response.Headers.WWWAuthenticate = Scheme.Name;
+			Response.Headers.Append("WWW-Authenticate", Scheme.Name);
 			return base.HandleChallengeAsync(properties);
 		}
 

--- a/NBXplorer/Authentication/BasicAuthenticationHandler.cs
+++ b/NBXplorer/Authentication/BasicAuthenticationHandler.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -9,44 +11,71 @@ using System.Threading.Tasks;
 
 namespace NBXplorer.Authentication
 {
-	public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticationOptions>
+	public class BasicAuthenticationHandler(
+		IOptionsMonitor<BasicAuthenticationOptions> options,
+		ILoggerFactory logger,
+		UrlEncoder encoder)
+		: AuthenticationHandler<BasicAuthenticationOptions>(options, logger, encoder)
 	{
-		public BasicAuthenticationHandler(IOptionsMonitor<BasicAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
-		{
-		}
-
 		protected override Task<AuthenticateResult> HandleAuthenticateAsync()
 		{
-			var authHeader = (string)this.Request.Headers["Authorization"];
-
 			if(Options.Username == null)
 			{
-				var user = new GenericPrincipal(new GenericIdentity("Anonymous"), null);
-				var ticket = new AuthenticationTicket(user, new AuthenticationProperties(), "Basic");
+				var user = new GenericPrincipal(new GenericIdentity("Anonymous", Scheme.Name), null);
+				var ticket = new AuthenticationTicket(user, new AuthenticationProperties(), Scheme.Name);
 				return Task.FromResult(AuthenticateResult.Success(ticket));
 			}
 
-			if(!string.IsNullOrEmpty(authHeader) && authHeader.StartsWith("basic", StringComparison.OrdinalIgnoreCase))
+			if(!Request.Headers.TryGetValue("Authorization", out var values))
+				return Task.FromResult(AuthenticateResult.NoResult());
+
+			if(values.Count != 1 ||
+			   !AuthenticationHeaderValue.TryParse(values[0], out var authorization) ||
+			   !authorization.Scheme.Equals(Scheme.Name, StringComparison.OrdinalIgnoreCase) ||
+			   string.IsNullOrWhiteSpace(authorization.Parameter))
+				return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization header."));
+
+			string usernamePassword;
+			try
 			{
-				//Extract credentials
-				string encodedUsernamePassword = authHeader.Substring("Basic ".Length).Trim();
-				Encoding encoding = Encoding.GetEncoding("iso-8859-1");
-				string usernamePassword = encoding.GetString(Convert.FromBase64String(encodedUsernamePassword));
+				usernamePassword = Encoding.Latin1.GetString(Convert.FromBase64String(authorization.Parameter));
+			}
+			catch(FormatException)
+			{
+				return Task.FromResult(AuthenticateResult.Fail("Invalid Basic credentials."));
+			}
 
-				int seperatorIndex = usernamePassword.IndexOf(':');
+			int separatorIndex = usernamePassword.IndexOf(':');
+			if(separatorIndex < 0)
+				return Task.FromResult(AuthenticateResult.Fail("Invalid Basic credentials."));
 
-				var username = usernamePassword.Substring(0, seperatorIndex);
-				var password = usernamePassword.Substring(seperatorIndex + 1);
+			var username = usernamePassword.Substring(0, separatorIndex);
+			var password = usernamePassword.Substring(separatorIndex + 1);
 
-				if(username.Equals(Options.Username, StringComparison.OrdinalIgnoreCase) && password.Equals(Options.Password, StringComparison.OrdinalIgnoreCase))
-				{
-					var user = new GenericPrincipal(new GenericIdentity(Options.Username), null);
-					var ticket = new AuthenticationTicket(user, new AuthenticationProperties(), "Basic");
-					return Task.FromResult(AuthenticateResult.Success(ticket));
-				}
+			if(username.Equals(Options.Username, StringComparison.Ordinal) && PasswordEquals(password, Options.Password))
+			{
+				var user = new GenericPrincipal(new GenericIdentity(Options.Username, Scheme.Name), null);
+				var ticket = new AuthenticationTicket(user, new AuthenticationProperties(), Scheme.Name);
+				return Task.FromResult(AuthenticateResult.Success(ticket));
 			}
 
 			return Task.FromResult(AuthenticateResult.Fail("No valid user."));
+		}
+
+		protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+		{
+			Response.Headers.WWWAuthenticate = Scheme.Name;
+			return base.HandleChallengeAsync(properties);
+		}
+
+		private static bool PasswordEquals(string password, string expectedPassword)
+		{
+			if(expectedPassword == null)
+				return false;
+
+			return CryptographicOperations.FixedTimeEquals(
+				SHA256.HashData(Encoding.UTF8.GetBytes(password)),
+				SHA256.HashData(Encoding.UTF8.GetBytes(expectedPassword)));
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- reject malformed Basic authentication headers without throwing
- compare credentials case-sensitively and verify passwords in fixed time
- advertise the Basic scheme on challenges and use the configured scheme consistently
- add focused tests for malformed, invalid, valid, and challenge behavior

## Testing
- `dotnet test NBXplorer.Tests/NBXplorer.Tests.csproj --filter FullyQualifiedName~BasicAuthenticationHandlerTests --no-restore`