### PR TITLE
Wait for P2P disconnect during shutdown

### DIFF
--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -575,7 +575,11 @@ namespace NBXplorer.Backend
 		public async Task StopAsync(CancellationToken cancellationToken)
 		{
 			cts?.Cancel();
-			_Connection?.Dispose("NBXplorer stopping...");
+			var connection = _Connection;
+			connection?.Dispose("NBXplorer stopping...");
+			// NBitcoin uses foreground threads for P2P connections. Wait until they
+			// exit so they cannot keep the process alive after host shutdown.
+			connection?.Node.Disconnect();
 			if (_indexerLoop is not null)
 				await _indexerLoop;
 			if (_watchdogLoop is not null)


### PR DESCRIPTION
## Summary

Wait for NBitcoin P2P connections to disconnect when NBXplorer stops.

NBitcoin uses foreground threads for its send and receive loops. Previously NBXplorer only requested asynchronous disconnection, allowing host shutdown to finish while those threads kept the process alive. Docker therefore waited for its full stop timeout before killing the container.

## Validation

- Reproduced consistently in btcpayserver-docker `test-install`: NBXplorer consumed the full 180-second stop timeout.
- Captured the process during shutdown: PostgreSQL had no active NBXplorer sessions, while the remaining managed stacks were NBitcoin P2P send/receive threads for BTC and LTC.
- `dotnet build NBXplorer/NBXplorer.csproj --no-restore -c Release`
- `git diff --check`