### PR TITLE
Fix NBXplorer slow at shutdown if DB unavailable

### DIFF
--- a/NBXplorer.Tests/ServerTester.cs
+++ b/NBXplorer.Tests/ServerTester.cs
@@ -42,6 +42,8 @@ namespace NBXplorer.Tests
 		{
 			if (Host != null)
 			{
+				_ = Host.StopAsync();
+				Host.WaitForShutdown();
 				Host.Dispose();
 				Host = null;
 			}

--- a/NBXplorer/HostedServices/RefreshWalletHistoryPeriodicTask.cs
+++ b/NBXplorer/HostedServices/RefreshWalletHistoryPeriodicTask.cs
@@ -26,7 +26,7 @@ namespace NBXplorer.HostedServices
 
 		public async Task Do(CancellationToken cancellationToken)
 		{
-			await using var conn = await _DS.ReliableOpenConnectionAsync();
+			await using var conn = await _DS.ReliableOpenConnectionAsync(cancellationToken);
 			var command = new CommandDefinition(
 				commandText: "SELECT wallets_history_refresh();",
 				commandType: System.Data.CommandType.Text,


### PR DESCRIPTION
Github actions in btcpayserver-docker was experiencing slow shutdown probably due to not passing CancellationToken properly.
