### PR TITLE
Require derivation auth and validate prune, scan, and group requests

### DIFF
--- a/NBXplorer.Tests/UnitTest1.Security.cs
+++ b/NBXplorer.Tests/UnitTest1.Security.cs
@@ -1,0 +1,106 @@
+using NBXplorer.Models;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public partial class UnitTest1
+	{
+		[FactWithTimeout]
+		public async Task DerivationEndpointsRequireAuthentication()
+		{
+			using var tester = CreateTesterNoAutoStart();
+			tester.Start();
+			tester.WaitSynchronized();
+
+			using var response = await tester.HttpClient.PostAsync("v1/cryptos/BTC/derivations", null);
+
+			Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+		}
+
+		[FactWithTimeout]
+		public async Task DerivationEndpointsAllowNoAuthentication()
+		{
+			using var tester = CreateTesterNoAutoStart();
+			tester.AdditionalFlags.Add("--noauth");
+			tester.Start();
+			tester.WaitSynchronized();
+
+			using var response = await tester.HttpClient.PostAsync("v1/cryptos/BTC/derivations", null);
+
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[FactWithTimeout]
+		public async Task PruneRejectsInvalidDaysToKeep()
+		{
+			using var tester = CreateTester();
+			tester.WaitSynchronized();
+			var wallet = await tester.Client.GenerateWalletAsync();
+			var invalidValues = new[]
+			{
+				-1.0,
+				double.NaN,
+				double.PositiveInfinity,
+				TimeSpan.MaxValue.TotalDays + 1.0
+			};
+
+			foreach (var daysToKeep in invalidValues)
+			{
+				await AssertBadRequest(
+					"invalid-days-to-keep",
+					() => tester.Client.PruneAsync(wallet.DerivationScheme, new PruneRequest { DaysToKeep = daysToKeep }));
+			}
+
+			await tester.Client.PruneAsync(wallet.DerivationScheme, new PruneRequest { DaysToKeep = 0.0 });
+		}
+
+		[FactWithTimeout]
+		public async Task ScanUTXOSetRejectsInvalidRanges()
+		{
+			using var tester = CreateTester();
+			tester.WaitSynchronized();
+			var invalidValues = new (int? BatchSize, int? GapLimit, int? From)[]
+			{
+				(0, null, null),
+				(null, 0, null),
+				(null, null, -1)
+			};
+
+			foreach (var value in invalidValues)
+			{
+				var wallet = await tester.Client.GenerateWalletAsync();
+				await AssertBadRequest(
+					"invalid-scan-parameters",
+					() => tester.Client.ScanUTXOSetAsync(wallet.DerivationScheme, value.BatchSize, value.GapLimit, value.From));
+			}
+		}
+
+		[FactWithTimeout]
+		public async Task GroupChildrenRejectsNullBodies()
+		{
+			using var tester = CreateTester();
+			tester.WaitSynchronized();
+			var group = await tester.Client.CreateGroupAsync();
+
+			await AssertBadRequest(
+				"invalid-group-children",
+				() => tester.Client.AddGroupChildrenAsync(group.GroupId, null));
+			await AssertBadRequest(
+				"invalid-group-children",
+				() => tester.Client.RemoveGroupChildrenAsync(group.GroupId, null));
+
+			var unchanged = await tester.Client.AddGroupChildrenAsync(group.GroupId, Array.Empty<GroupChild>());
+			Assert.Empty(unchanged.Children);
+		}
+
+		private static async Task AssertBadRequest(string expectedCode, Func<Task> action)
+		{
+			var exception = await Assert.ThrowsAsync<NBXplorerException>(action);
+			Assert.Equal(400, exception.Error.HttpCode);
+			Assert.Equal(expectedCode, exception.Error.Code);
+		}
+	}
+}

--- a/NBXplorer/Controllers/DerivationSchemesController.cs
+++ b/NBXplorer/Controllers/DerivationSchemesController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using NBitcoin;
 using NBXplorer.Backend;
 using NBXplorer.DerivationStrategy;
@@ -17,6 +18,7 @@ using NBitcoin.WalletPolicies;
 namespace NBXplorer.Controllers
 {
 	[Route($"v1/{CommonRoutes.BaseDerivationEndpoint}")]
+	[Authorize]
 	public class DerivationSchemesController : Controller
 	{
 		public ScanUTXOSetService ScanUTXOSetService { get; }
@@ -109,6 +111,9 @@ namespace NBXplorer.Controllers
 		[TrackedSourceContext.TrackedSourceContextRequirement(requireRPC: true, allowedTrackedSourceTypes: typeof(DerivationSchemeTrackedSource))]
 		public IActionResult ScanUTXOSet(TrackedSourceContext trackedSourceContext, int? batchSize = null, int? gapLimit = null, int? from = null)
 		{
+			if (batchSize is <= 0 || gapLimit is <= 0 || from is < 0)
+				throw new NBXplorerError(400, "invalid-scan-parameters", "Batch size and gap limit must be positive, and from must be non-negative").AsException();
+
 			var network = trackedSourceContext.Network;
 			var rpc = trackedSourceContext.RpcClient;
 			var derivationScheme = ((DerivationSchemeTrackedSource)trackedSourceContext.TrackedSource).DerivationStrategy;
@@ -145,6 +150,18 @@ namespace NBXplorer.Controllers
 		{
 			request ??= new PruneRequest();
 			request.DaysToKeep ??= 1.0;
+			if (!double.IsFinite(request.DaysToKeep.Value) || request.DaysToKeep.Value < 0.0 || request.DaysToKeep.Value > TimeSpan.MaxValue.TotalDays)
+				throw new NBXplorerError(400, "invalid-days-to-keep", "Days to keep must be a finite, non-negative duration").AsException();
+
+			TimeSpan timeToKeep;
+			try
+			{
+				timeToKeep = TimeSpan.FromDays(request.DaysToKeep.Value);
+			}
+			catch (OverflowException)
+			{
+				throw new NBXplorerError(400, "invalid-days-to-keep", "Days to keep must fit within a TimeSpan").AsException();
+			}
 			var trackedSource = trackedSourceContext.TrackedSource;
 			var network = trackedSourceContext.Network;
 			var repo = trackedSourceContext.Repository;
@@ -153,7 +170,7 @@ namespace NBXplorer.Controllers
 			var state = transactions.ConfirmedState;
 			var prunableIds = new HashSet<uint256>();
 
-			var keepConfMax = network.NBitcoinNetwork.Consensus.GetExpectedBlocksFor(TimeSpan.FromDays(request.DaysToKeep.Value));
+			var keepConfMax = network.NBitcoinNetwork.Consensus.GetExpectedBlocksFor(timeToKeep);
 			var tip = (await repo.GetTip()).Height;
 			// Step 1. We can prune if all UTXOs are spent
 			foreach (var tx in transactions.ConfirmedTransactions)

--- a/NBXplorer/Controllers/GroupsController.cs
+++ b/NBXplorer/Controllers/GroupsController.cs
@@ -83,6 +83,7 @@ namespace NBXplorer.Controllers
 		[HttpPost($"{CommonRoutes.GroupEndpoint}/children/delete")]
 		public async Task<IActionResult> DeleteGroupChildren(string groupId, [FromBody] GroupChild[] children)
 		{
+			EnsureGroupChildren(children);
 			var w = Repository.GetWalletKey(new GroupTrackedSource(groupId));
 			await using (var conn = await ConnectionFactory.CreateConnection())
 			{
@@ -99,6 +100,7 @@ namespace NBXplorer.Controllers
 		[HttpDelete($"{CommonRoutes.GroupEndpoint}/children")]
 		public async Task<IActionResult> AddDeleteGroupChildren(string groupId, [FromBody] GroupChild[] children)
 		{
+			EnsureGroupChildren(children);
 			if (HttpContext.Request.Method == "DELETE")
 				return await DeleteGroupChildren(groupId, children);
 			var w = Repository.GetWalletKey(new GroupTrackedSource(groupId));
@@ -122,6 +124,12 @@ namespace NBXplorer.Controllers
 				}
 			}
 			return await GetGroup(groupId);
+		}
+
+		private static void EnsureGroupChildren(GroupChild[] children)
+		{
+			if (children is null)
+				throw new NBXplorerException(new NBXplorerError(400, "invalid-group-children", "Group children are required"));
 		}
 
 		[HttpPost($"{CommonRoutes.BaseCryptoEndpoint}/{CommonRoutes.GroupEndpoint}/addresses")]


### PR DESCRIPTION
## What changes

This PR fixes four request-boundary bugs in NBXplorer's HTTP API. It does **not** change the test-only Docker Compose manifests or treat their regtest credentials and published ports as production configuration.

### 1. Require authentication on derivation-scheme administration

**Code:** `DerivationSchemesController` now has a class-level `[Authorize]` attribute.

That controller owns the endpoints that create and track derivation schemes or addresses, wipe and scan UTXOs, read scan status, prune transactions, generate wallets, and manage metadata/PSBT operations. Previously, the controller had no authorization attribute, so those actions could run without passing through the configured authentication boundary.

Concrete behavior:

| Server mode | Before | After |
| --- | --- | --- |
| Normal authentication | An unauthenticated `POST /v1/cryptos/BTC/derivations` reached the action and returned 200 | The same request is rejected with 401 before the action runs |
| Explicit `--noauth` | Request succeeded | Request still succeeds with 200 |

The `--noauth` case is intentionally preserved. NBXplorer's existing authentication handler creates the anonymous authenticated principal in that mode, so adding `[Authorize]` does not turn authentication back on for deployments that explicitly disabled it.

**Scanner item:** `custos_1xdd1ht`

### 2. Validate `daysToKeep` before pruning

**Endpoint:** `POST /v1/cryptos/{cryptoCode}/derivations/{derivationScheme}/prune`

Previously, invalid floating-point values were allowed to reach duration conversion and pruning calculations. Depending on the value, this could accept a nonsensical retention period or surface an unhandled conversion failure as HTTP 500.

The endpoint now applies this contract before loading annotated transactions or calculating the expected block count:

| `daysToKeep` | Result |
| --- | --- |
| Omitted or request body omitted | Use the existing 1-day default |
| `0` | Accepted; preserves the existing aggressive-prune behavior |
| Positive, finite value within `TimeSpan` range | Accepted |
| Negative | 400 `invalid-days-to-keep` |
| `NaN`, positive infinity, or negative infinity | 400 `invalid-days-to-keep` |
| Greater than `TimeSpan.MaxValue.TotalDays` | 400 `invalid-days-to-keep` |

After validation, the value is converted to a `TimeSpan` once and that validated value is reused by the pruning calculation. A defensive `OverflowException` mapping also returns the same 400-class API error rather than leaking a 500.

**Scanner item:** `custos_1lsakf1`

### 3. Reject invalid UTXO scan ranges before queueing work

**Endpoint:** `POST /v1/cryptos/{cryptoCode}/derivations/{derivationScheme}/utxos/scan`

The optional query parameters now have explicit bounds:

| Parameter | Valid values | Rejected values |
| --- | --- | --- |
| `batchSize` | Omitted or greater than 0 | 0 or negative |
| `gapLimit` | Omitted or greater than 0 | 0 or negative |
| `from` | Omitted or 0 and above | Negative |

An invalid request returns HTTP 400 with code `invalid-scan-parameters` before `ScanUTXOSetService.EnqueueScan` is called. This matters because the old path copied the values directly into `ScanUTXOSetOptions`; for example, `batchSize=0` could create invalid background work and prevent the scan loop from making progress.

The existing behavior for omitted parameters, unsupported currencies (405), and an already-running scan (409) is unchanged.

**Scanner item:** `custos_134wqyk`

### 4. Return a client error for null group-child bodies

**Endpoints:**

- `POST /v1/groups/{groupId}/children`
- `DELETE /v1/groups/{groupId}/children`
- `POST /v1/groups/{groupId}/children/delete` (legacy delete route)

Previously, a JSON `null` body reached `children.Select(...)`, raised `ArgumentNullException`, and became HTTP 500. Both add and delete paths now check the body before any LINQ or database work and return:

```text
HTTP 400
code: invalid-group-children
message: Group children are required
```

An empty JSON array remains a valid no-op. Existing handling for unknown children, cycle detection, foreign-key failures, and valid add/remove operations is unchanged.

**Scanner item:** `custos_cudnh4`

## Files changed

- `NBXplorer/Controllers/DerivationSchemesController.cs`
  - Adds the controller-level authorization boundary.
  - Adds prune-duration validation and one-time conversion.
  - Adds UTXO scan parameter validation before queueing.
- `NBXplorer/Controllers/GroupsController.cs`
  - Adds the shared null-body guard used by current and legacy child-removal routes.
- `NBXplorer.Tests/UnitTest1.Security.cs`
  - Adds end-to-end regression tests through the HTTP client and running NBXplorer test server.

## Regression coverage

| Test | Contract exercised |
| --- | --- |
| `DerivationEndpointsRequireAuthentication` | Unauthenticated derivation request returns 401 in normal mode |
| `DerivationEndpointsAllowNoAuthentication` | The same request returns 200 with explicit `--noauth` |
| `PruneRejectsInvalidDaysToKeep` | Rejects `-1`, `NaN`, positive infinity, and an out-of-range duration; accepts `0` |
| `ScanUTXOSetRejectsInvalidRanges` | Rejects `batchSize=0`, `gapLimit=0`, and `from=-1` |
| `GroupChildrenRejectsNullBodies` | Rejects null add/remove bodies and preserves the empty-array no-op |

Pre-fix behavior was reproduced locally: the unauthenticated derivation request returned 200, negative prune retention was accepted, a null group-child body produced an HTTP 500 from LINQ, and a zero-sized scan batch entered invalid background work. The new tests pass after the patch.

Additional regression checks:

- Existing `CanPrune`, `CanPrune2`, `CanScanUTXOSet`, and `CanCRUDGroups` tests pass when run individually.
- `BasicAuthenticationHandlerTests`: 6/6 pass.
- `dotnet build NBXplorer.sln --no-restore --configuration Release`: succeeds.
- Both Linux CI jobs pass on commit `20d0c728c9660c549849fb6e6ca2973683b59000`.
- CodeRabbit reports success on the same head commit with no actionable findings.

The broader local Windows integration run can intermittently finish assertions and then fail during fixture teardown while deleting `btc_fully_synched`. Each affected test passes in isolation; the two Linux CI runs are green.

## Explicit non-goals: Compose findings

The following files are test fixtures, not production deployment definitions:

- `docker-compose.mutiny.yml`
- `docker-compose.regtest.yml`
- `NBXplorer.Tests/docker-compose.yml`

Therefore this PR deliberately does not change:

- Bitcoin Core RPC/P2P port publishing used by the test networks.
- Static regtest/signet credentials.
- PostgreSQL trust authentication in the test database.
- `--noauth` used by isolated test services.

The related “publicly exposed Bitcoin RPC” and “PostgreSQL with trust authentication” scanner items were reclassified as false positives because their exploit scenario assumes these test Compose stacks are production services exposed to an untrusted network. That assumption is outside NBXplorer's deployment model and outside the purpose of these fixtures.
