### PR TITLE
Match fork-recovery blocks to headers by hash

### DIFF
--- a/NBXplorer.Tests/IndexerTests.cs
+++ b/NBXplorer.Tests/IndexerTests.cs
@@ -1,0 +1,32 @@
+using NBitcoin;
+using NBXplorer.Backend;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class IndexerTests
+	{
+		[Fact]
+		public void UnorderedBlocksAreMatchedToHeadersByHash()
+		{
+			var first = Network.RegTest.Consensus.ConsensusFactory.CreateBlock();
+			var second = Network.RegTest.Consensus.ConsensusFactory.CreateBlock();
+			second.Header.HashPrevBlock = first.GetHash();
+			var headers = new BlockHeaders(new[]
+			{
+				new RPCBlockHeader(first.GetHash(), first.Header.HashPrevBlock, 10, DateTimeOffset.UnixEpoch, first.Header.HashMerkleRoot),
+				new RPCBlockHeader(second.GetHash(), second.Header.HashPrevBlock, 11, DateTimeOffset.UnixEpoch, second.Header.HashMerkleRoot)
+			});
+
+			var matched = Indexer.MatchBlocksToHeaders(new[] { second, first }, headers).ToArray();
+
+			Assert.Collection(
+				matched,
+				pair => Assert.Equal(first.GetHash(), pair.Header.Hash),
+				pair => Assert.Equal(second.GetHash(), pair.Header.Hash));
+			Assert.All(matched, pair => Assert.Equal(pair.Block.GetHash(), pair.Header.Hash));
+		}
+	}
+}

--- a/NBXplorer/Backend/Indexer.cs
+++ b/NBXplorer/Backend/Indexer.cs
@@ -184,18 +184,17 @@ namespace NBXplorer.Backend
 									// If there is a fork, we should index the unordered blocks
 									bool unconfedBlocks = false;
 									bool fork = await RPCClient.GetBlockHeaderAsyncEx(lastIndexedBlock.Hash, token) == null;
-									foreach (var b in Enumerable.Zip(unorderedBlocks, slimChainedBlocks)
-													.Where(b => fork || b.Second.Height > lastIndexedBlock.Height)
-													.OrderBy(b => b.Second.Height)
+									foreach (var b in MatchBlocksToHeaders(unorderedBlocks, slimChainedBlocks)
+													.Where(b => fork || b.Header.Height > lastIndexedBlock.Height)
 													.ToList())
 									{
-										var slimBlock = b.Second;
+										var slimBlock = b.Header;
 										if (fork && !unconfedBlocks)
 										{
 											await conn.MakeOrphanFrom(slimBlock.Height);
 											unconfedBlocks = true;
 										}
-										await SaveMatches(conn, b.First, slimBlock.ToSlimChainedBlock());
+										await SaveMatches(conn, b.Block, slimBlock.ToSlimChainedBlock());
 									}
 								}
 								break;
@@ -213,6 +212,17 @@ namespace NBXplorer.Backend
 					await SaveMatches(conn, txs, null, true);
 				}
 			}
+		}
+
+		internal static IEnumerable<(Block Block, RPCBlockHeader Header)> MatchBlocksToHeaders(IEnumerable<Block> blocks, BlockHeaders headers)
+		{
+			var matches = new List<(Block Block, RPCBlockHeader Header)>();
+			foreach (var block in blocks)
+			{
+				if (headers.ByHashes.TryGetValue(block.GetHash(), out var header))
+					matches.Add((block, header));
+			}
+			return matches.OrderBy(match => match.Header.Height);
 		}
 
 		// Attempt to pull as much non-conflicting transactions as possible in one batch


### PR DESCRIPTION
## Why

Fork recovery fetches block headers and blocks in separate RPC calls. The block RPC result is explicitly treated as unordered, but the existing code paired blocks and headers by array position with `Zip`. If bitcoind returned the blocks in a different order, NBXplorer could save a block using another block's height and chain metadata.

## What changed

- Match every returned block to its header by the block hash instead of its position in the RPC response.
- Ignore a returned block that has no corresponding header rather than attaching unrelated metadata.
- Sort the matched pairs by header height before orphaning and saving them, preserving the intended chain-order processing.
- Keep the existing fork and last-indexed-height filtering behavior unchanged.

## Security impact

This removes the positional-association assumption from fork recovery. A reordered `getblock` response can no longer cause the indexer to persist a block under the wrong height/header, preventing index corruption and incorrect wallet history derived from mismatched chain data.

Addresses Prem Security finding `custos_10phwu0`.

## Tests

- Added `IndexerTests.UnorderedBlocksAreMatchedToHeadersByHash`, which passes blocks in reverse order and verifies both height ordering and hash equality for every block/header pair.
- `dotnet test NBXplorer.Tests/NBXplorer.Tests.csproj --filter "FullyQualifiedName~IndexerTests" --no-restore --verbosity minimal` — 1 passed.
- `dotnet build NBXplorer.sln -c Release --no-restore --verbosity minimal` — succeeded with 0 errors.
- `docker compose build` and `docker compose run --rm tests` from `NBXplorer.Tests` — 99 passed, 0 failed.

## Scope

This PR only changes block/header association during fork recovery. It does not change normal indexing, RPC configuration, database schema, or deployment defaults.
