### PR TITLE
Fix PSBT minimum-value filtering and asset scale overflow

### DIFF
--- a/NBXplorer.Client/AssetMoney.cs
+++ b/NBXplorer.Client/AssetMoney.cs
@@ -118,7 +118,7 @@ namespace NBXplorer
 			int dec = 1;
 			for (int i = 0; i < divisibility; i++)
 			{
-				dec = dec * 10;
+				dec = checked(dec * 10);
 			}
 			return dec;
 		}

--- a/NBXplorer.Tests/AssetMoneyTests.cs
+++ b/NBXplorer.Tests/AssetMoneyTests.cs
@@ -1,0 +1,28 @@
+using NBitcoin;
+using System;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class AssetMoneyTests
+	{
+		[Fact]
+		public void RejectsDivisibilityThatOverflowsScale()
+		{
+			var assetId = uint256.One;
+
+			Assert.Throws<OverflowException>(() => new AssetMoney(assetId, 1.0m, 10));
+			Assert.Throws<OverflowException>(() => new AssetMoney(assetId, 1L).ToDecimal(10));
+		}
+
+		[Fact]
+		public void SupportsBitcoinStyleDivisibility()
+		{
+			var assetId = uint256.One;
+			var amount = new AssetMoney(assetId, 1.23456789m, 8);
+
+			Assert.Equal(123456789L, amount.Quantity);
+			Assert.Equal(1.23456789m, amount.ToDecimal(8));
+		}
+	}
+}

--- a/NBXplorer.Tests/UnitTest1.cs
+++ b/NBXplorer.Tests/UnitTest1.cs
@@ -855,7 +855,7 @@ namespace NBXplorer.Tests
 								SweepAll = true
 							}
 						},
-				MinValue = Money.Coins(1.0m),
+				MinValue = Money.Coins(0.1m),
 				FeePreference = new FeePreference()
 				{
 					ExplicitFee = Money.Coins(0.000001m),
@@ -867,7 +867,7 @@ namespace NBXplorer.Tests
 			var actualOutpoints = psbt2.PSBT.GetGlobalTransaction().Inputs.Select(i => i.PrevOut).ToArray();
 			Assert.Single(actualOutpoints);
 			Assert.Equal(outpoints[0], actualOutpoints[0]);
-			request.MinValue = Money.Coins(0.1m);
+			request.MinValue = Money.Coins(1.1m);
 			ex = Assert.Throws<NBXplorerException>(() => tester.Client.CreatePSBT(userDerivationScheme, request));
 			Assert.Equal("not-enough-funds", ex.Error.Code);
 

--- a/NBXplorer/Controllers/MainController.PSBT.cs
+++ b/NBXplorer/Controllers/MainController.PSBT.cs
@@ -187,7 +187,7 @@ namespace NBXplorer.Controllers
 
 			if (request.MinValue != null)
 			{
-				availableCoinsByOutpoint = availableCoinsByOutpoint.Where(c => request.MinValue >= (Money)c.Value.Value).ToDictionary(o => o.Key, o => o.Value);
+				availableCoinsByOutpoint = availableCoinsByOutpoint.Where(c => request.MinValue <= (Money)c.Value.Value).ToDictionary(o => o.Key, o => o.Value);
 			}
 
 			var unconfUtxos = utxos.Where(u => u.Confirmations is 0).ToList();


### PR DESCRIPTION
## Why

Two independent money-boundary bugs could produce incorrect transaction construction or arithmetic:

1. `CreatePSBTRequest.MinValue` is documented as the floor below which UTXOs are ignored, but the filter used the comparison in the opposite direction. That retained values at or below the floor and rejected values above it.
2. `AssetMoney.Pow10` multiplied an `int` outside a checked expression. Divisibility 10 or greater wrapped the scale instead of failing, even when the caller used a checked block.

## What changed

### PSBT minimum-value filtering

- Retain a UTXO when its value is greater than or equal to `MinValue`.
- Continue applying `IncludeOnlyOutpoints`, `ExcludeOutpoints`, and confirmation filtering exactly as before.
- Update the existing end-to-end PSBT test so a 0.1 BTC floor accepts the selected 1 BTC UTXO and a 1.1 BTC floor rejects it with `not-enough-funds`.

### AssetMoney divisibility

- Perform every power-of-ten multiplication in a checked expression.
- Preserve divisibility values through 9, including the common 8-decimal scale.
- Throw `OverflowException` instead of returning a wrapped scale when the requested divisibility cannot fit in the existing `int` representation.

## Security impact

The PSBT fix restores the caller-requested UTXO floor and prevents unexpectedly selecting smaller coins while excluding larger eligible coins. The arithmetic fix prevents wrapped asset scales from silently changing quantities or decimal conversion results.

Addresses Prem Security findings `custos_wi5nzf` and `custos_szxbux`.

## Tests

- Demonstrated both regressions before the production changes: all three `CanCreatePSBT` cases rejected the valid 0.1 BTC-floor request, and `RejectsDivisibilityThatOverflowsScale` observed no exception.
- Added `AssetMoneyTests` for overflow rejection and exact 8-decimal round-tripping.
- Updated all three existing `CanCreatePSBT` theory cases for the correct minimum-value semantics.
- `docker compose build` and `docker compose run --rm tests` from `NBXplorer.Tests` — 100 passed, 0 failed.
- `dotnet build NBXplorer.sln -c Release --no-restore --verbosity minimal` — succeeded with 0 errors.

## Compatibility

No request or response schema changes. Requests that depended on the inverted `MinValue` behavior will now follow the documented contract.
