### PR TITLE
Handle RPC outages and cap scan retry backoff

### DIFF
--- a/NBXplorer.Tests/RPCClientExtensionsTests.cs
+++ b/NBXplorer.Tests/RPCClientExtensionsTests.cs
@@ -1,0 +1,34 @@
+using NBitcoin;
+using NBitcoin.RPC;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class RPCClientExtensionsTests
+	{
+		[Fact]
+		public async Task MissingRpcReturnsNoTransactionsFromBlocks()
+		{
+			RPCClient rpc = null;
+			var requested = new HashSet<(uint256 BlockId, uint256 TransactionId)>
+			{
+				(uint256.One, new uint256(2))
+			};
+
+			var result = await rpc.GetTransactionFromBlocks(requested);
+
+			Assert.Empty(result);
+		}
+
+		[Theory]
+		[InlineData(100, 200)]
+		[InlineData(5_000, 10_000)]
+		[InlineData(10_000, 10_000)]
+		public void ScanRetryDelayDoublesUpToTenSeconds(int current, int expected)
+		{
+			Assert.Equal(expected, RPCClientExtensions.NextScanRetryDelay(current));
+		}
+	}
+}

--- a/NBXplorer/RPCClientExtensions.cs
+++ b/NBXplorer/RPCClientExtensions.cs
@@ -86,6 +86,8 @@ namespace NBXplorer
 
 	public static class RPCClientExtensions
 	{
+		internal static int NextScanRetryDelay(int currentDelay) => Math.Min(currentDelay * 2, 10_000);
+
 		public static async Task<ScanTxoutSetResponse> StartScanTxoutSetExAsync(this RPCClient rpc, ScanTxoutSetParameters parameters, CancellationToken cancellationToken)
 		{
 			int delay = 100;
@@ -97,7 +99,7 @@ namespace NBXplorer
 			catch (RPCException ex) when (!cancellationToken.IsCancellationRequested && ex.Message.StartsWith("Scan already in progress", StringComparison.OrdinalIgnoreCase))
 			{
 				await Task.Delay(delay, cancellationToken);
-				delay = Math.Max(delay * 2, 10_000);
+				delay = NextScanRetryDelay(delay);
 				goto retry;
 			}
 		}
@@ -418,6 +420,9 @@ namespace NBXplorer
 
 		public static async Task<Dictionary<uint256, Transaction>> GetTransactionFromBlocks(this RPCClient rpc, HashSet<(uint256 BlockId, uint256 TransactionId)> txBlockIds, CancellationToken cancellationToken = default)
 		{
+			if (rpc is null || txBlockIds.Count == 0)
+				return new Dictionary<uint256, Transaction>();
+
 			async Task<Dictionary<uint256, Transaction>> GetTransactionFromStoredBlocks(HashSet<(uint256 BlockId, uint256 TransactionId)> txBlockIds)
 			{
 				var result = new Dictionary<uint256, Transaction>();


### PR DESCRIPTION
## Why

Two recovery paths behaved poorly while Bitcoin RPC was unavailable or busy:

1. `UTXOFetcherService` can operate without an RPC client, but its block fallback called `GetTransactionFromBlocks` unconditionally. A non-empty set of block references then dereferenced the missing client while preparing a batch.
2. `StartScanTxoutSetExAsync` used `Math.Max` for retry backoff. The first collision jumped from 100 ms to 10 seconds, and later retries grew to 20, 40, 80 seconds without a ceiling.

## What changed

### Missing RPC client

- `GetTransactionFromBlocks` now returns an empty dictionary immediately when the RPC client is unavailable.
- The same fast path handles an empty request set without preparing or sending a batch.
- The caller remains best-effort: locally stored PSBT data is preserved, and later fallback logic is skipped safely until RPC connectivity is available.

### Scan retry backoff

- Retry delay now doubles from 100 ms and is capped at 10 seconds.
- Cancellation behavior and the existing retry condition for Bitcoin Core's "Scan already in progress" response are unchanged.

## Security and reliability impact

Temporary RPC outages no longer turn PSBT/UTXO enrichment into a null-reference failure. Concurrent UTXO-set scans no longer impose an immediate 10-second penalty or unbounded retry delays, while still avoiding a tight retry loop against Bitcoin Core.

Addresses Prem Security findings `custos_r9mwvl` and `custos_k8sr2i`.

## Tests

- Added a regression test that calls block transaction recovery with a null RPC client and a non-empty request, verifying an empty result instead of an exception.
- Added retry-delay boundary cases for 100 ms, 5 seconds, and the 10-second cap.
- Focused tests: 4 passed, 0 failed.
- `dotnet build NBXplorer.sln -c Release --no-restore --verbosity minimal` — succeeded with 0 errors.
- `docker compose build` and `docker compose run --rm tests` from `NBXplorer.Tests` — 102 passed, 0 failed.

## Scope

No RPC authentication, endpoint, or request schema changes. This PR only changes behavior during a missing RPC client and repeated scan-contention responses.
