### PR TITLE
Bound wallet address generation requests

### DIFF
--- a/NBXplorer.Tests/DerivationSchemesControllerTests.cs
+++ b/NBXplorer.Tests/DerivationSchemesControllerTests.cs
@@ -1,0 +1,51 @@
+using NBXplorer.Controllers;
+using NBXplorer.Models;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class DerivationSchemesControllerTests
+	{
+		[Theory]
+		[InlineData(-1, null)]
+		[InlineData(null, -1)]
+		[InlineData(2, 1)]
+		[InlineData(10_001, null)]
+		[InlineData(null, 10_001)]
+		public void RejectsInvalidAddressGenerationRanges(int? minAddresses, int? maxAddresses)
+		{
+			var request = new TrackWalletRequest
+			{
+				DerivationOptions = new[]
+				{
+					new TrackDerivationOption
+					{
+						MinAddresses = minAddresses,
+						MaxAddresses = maxAddresses
+					}
+				}
+			};
+
+			var exception = Assert.Throws<NBXplorerException>(() => DerivationSchemesController.ValidateDerivationOptions(request));
+
+			Assert.Equal(400, exception.Error.HttpCode);
+			Assert.Equal("invalid-address-generation-range", exception.Error.Code);
+		}
+
+		[Fact]
+		public void AcceptsBoundedAddressGenerationRanges()
+		{
+			var request = new TrackWalletRequest
+			{
+				DerivationOptions = new[]
+				{
+					new TrackDerivationOption { MinAddresses = 0, MaxAddresses = 0 },
+					new TrackDerivationOption { MinAddresses = 500, MaxAddresses = 10_000 },
+					new TrackDerivationOption()
+				}
+			};
+
+			DerivationSchemesController.ValidateDerivationOptions(request);
+		}
+	}
+}

--- a/NBXplorer/Controllers/DerivationSchemesController.cs
+++ b/NBXplorer/Controllers/DerivationSchemesController.cs
@@ -21,6 +21,8 @@ namespace NBXplorer.Controllers
 	[Authorize]
 	public class DerivationSchemesController : Controller
 	{
+		internal const int MaxAddressesPerRequest = 10_000;
+
 		public ScanUTXOSetService ScanUTXOSetService { get; }
 		public MainController MainController { get; }
 		public RepositoryProvider RepositoryProvider { get; }
@@ -53,6 +55,7 @@ namespace NBXplorer.Controllers
 			var network = trackedSourceContext.Network;
 			var trackedSource = trackedSourceContext.TrackedSource;
 			var request = network.ParseJObject<TrackWalletRequest>(rawRequest ?? new JObject());
+			ValidateDerivationOptions(request);
 
 			if (trackedSource is DerivationSchemeTrackedSource dts)
 			{
@@ -80,6 +83,22 @@ namespace NBXplorer.Controllers
 				await RepositoryProvider.GetRepository(network).Track(ats);
 			}
 			return Ok();
+		}
+
+		internal static void ValidateDerivationOptions(TrackWalletRequest request)
+		{
+			foreach (var option in request?.DerivationOptions ?? Array.Empty<TrackDerivationOption>())
+			{
+				if (option.MinAddresses is < 0 || option.MaxAddresses is < 0 ||
+					option.MinAddresses > MaxAddressesPerRequest || option.MaxAddresses > MaxAddressesPerRequest ||
+					option.MinAddresses is int min && option.MaxAddresses is int max && min > max)
+				{
+					throw new NBXplorerError(
+						400,
+						"invalid-address-generation-range",
+						$"Address generation counts must be between 0 and {MaxAddressesPerRequest}, and minAddresses cannot exceed maxAddresses").AsException();
+				}
+			}
 		}
 
 		private GenerateAddressQuery GenerateAddressQuery(TrackWalletRequest request, DerivationFeature feature)


### PR DESCRIPTION
## Dependency

This PR is intentionally stacked on #554 because both changes validate the authenticated derivation/admin request boundary. Review the two-file delta against `feat/nbxplorer-admin-api-validation-pr`; after #554 merges, this branch can be rebased or retargeted to `master` without changing this patch.

## Why

`TrackWalletRequest.DerivationOptions` accepts caller-provided `minAddresses` and `maxAddresses`. Both the synchronous `wait=true` path and the queued `wait=false` path forwarded those integers to address derivation without validating sign, ordering, or size.

`Repository.GenerateAddressesCore` allocates arrays proportional to the requested count, performs CPU-heavy key derivation, and inserts the resulting scripts in 10,000-row chunks. An authenticated client could therefore request an extreme count and create disproportionate memory, CPU, and database work.

## What changed

- Validate every supplied derivation option before any wallet tracking or address generation starts.
- Reject negative `minAddresses` or `maxAddresses`.
- Reject a range where `minAddresses` is greater than `maxAddresses`.
- Reject either value above 10,000, matching the repository's existing maximum insertion chunk.
- Return HTTP 400 with stable code `invalid-address-generation-range` and a concrete constraint message.
- Apply the same validation to both `wait=true` and `wait=false`; the background queue can no longer bypass the bound.

## Preserved behavior

- Null/omitted limits remain valid and retain default gap-pool behavior.
- Zero remains a valid explicit bound.
- Existing bounded requests remain supported; the 500-address end-to-end test passes unchanged.
- Feature selection and address derivation semantics are unchanged after validation.

## Security impact

Per-request address generation is now bounded before proportional allocation, elliptic-curve derivation, or database insertion. This prevents a single authenticated tracking request from scheduling an attacker-selected, effectively unbounded workload.

Addresses Prem Security findings `custos_1t2l0jh` and `custos_hqhxx2`.

## Tests

- Added rejection cases for negative minimum, negative maximum, reversed ranges, and each value above 10,000.
- Added acceptance cases for zero, 500, the exact 10,000 boundary, and omitted values.
- Existing `CanTrackManyAddressesAtOnce` integration test — 1 passed.
- `dotnet build NBXplorer.sln -c Release --no-restore --verbosity minimal` — succeeded with 0 errors.
- `docker compose build` and `docker compose run --rm tests` from `NBXplorer.Tests` — 109 passed, 0 failed.

## Out of scope

This does not change the configured normal gap-pool size or impose a global rate limit. It constrains only caller-supplied per-request generation counts.
