### PR TITLE
Limit RPC proxy batches and rescan fan-out

### DIFF
--- a/NBXplorer.Tests/MainControllerTests.cs
+++ b/NBXplorer.Tests/MainControllerTests.cs
@@ -1,0 +1,29 @@
+using NBXplorer.Controllers;
+using NBXplorer.Models;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class MainControllerTests
+	{
+		[Fact]
+		public void RejectsOversizedRpcBatches()
+		{
+			var exception = Assert.Throws<NBXplorerException>(() => MainController.ValidateRPCBatchSize(101));
+
+			Assert.Equal(400, exception.Error.HttpCode);
+			Assert.Equal("rpc-batch-too-large", exception.Error.Code);
+			MainController.ValidateRPCBatchSize(100);
+		}
+
+		[Fact]
+		public void RejectsOversizedRescans()
+		{
+			var exception = Assert.Throws<NBXplorerException>(() => MainController.ValidateRescanCount(1_001));
+
+			Assert.Equal(400, exception.Error.HttpCode);
+			Assert.Equal("rescan-too-large", exception.Error.Code);
+			MainController.ValidateRescanCount(1_000);
+		}
+	}
+}

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -94,6 +94,21 @@ namespace NBXplorer.Controllers
 			"getblockhash",
 			"getblockheader"
 		};
+		internal const int MaxRPCBatchSize = 100;
+		internal const int MaxRescanTransactions = 1_000;
+
+		internal static void ValidateRPCBatchSize(int count)
+		{
+			if (count > MaxRPCBatchSize)
+				throw new NBXplorerError(400, "rpc-batch-too-large", $"JSON-RPC batches cannot contain more than {MaxRPCBatchSize} requests").AsException();
+		}
+
+		internal static void ValidateRescanCount(int count)
+		{
+			if (count > MaxRescanTransactions)
+				throw new NBXplorerError(400, "rescan-too-large", $"Rescan requests cannot contain more than {MaxRescanTransactions} transactions").AsException();
+		}
+
 		internal NBXplorerNetwork GetNetwork(string cryptoCode, bool checkRPC)
 		{
 			if (cryptoCode == null)
@@ -137,6 +152,7 @@ namespace NBXplorer.Controllers
 			var req = RPCProxyRequest.TryParse(jsonRPC);
 			if (req is RPCProxyRequest.RPCProxyBatchedRequest batch)
 			{
+				ValidateRPCBatchSize(batch.Requests.Count);
 				var batchRPC = rpc.PrepareBatch();
 				if (batch.Requests.Count is 0)
 					return Json(new JArray());
@@ -717,6 +733,7 @@ namespace NBXplorer.Controllers
 				throw new ArgumentNullException(nameof(rescanRequest));
 			if (rescanRequest?.Transactions == null)
 				throw new NBXplorerException(new NBXplorerError(400, "transactions-missing", "You must specify 'transactions'"));
+			ValidateRescanCount(rescanRequest.Transactions.Count);
 
 			bool willFetchTransactions = rescanRequest.Transactions.Any(t => t.Transaction == null);
 			if (willFetchTransactions && trackedSourceContext.RpcClient is null)


### PR DESCRIPTION
## Why

Two authenticated HTTP endpoints converted caller-controlled arrays directly into Bitcoin Core work:

- The JSON-RPC proxy accepted an arbitrary number of requests, prepared the entire RPC batch, awaited every response, and materialized the complete response array.
- The rescan endpoint created one fetch task per submitted transaction, sent them as a batch, fetched referenced block headers, and wrote matches grouped by block.

Method whitelisting limits which proxy operations are callable, but it does not limit the amount of work in one request.

## What changed

### JSON-RPC proxy

- Accept at most 100 requests in one JSON-RPC batch.
- Reject 101 or more with HTTP 400 and stable code `rpc-batch-too-large`.
- Perform the count check before `PrepareBatch`, task creation, any Bitcoin Core call, or response-array allocation.
- Preserve empty-batch behavior and all existing method authorization checks.

### Rescan

- Accept at most 1,000 transaction entries in one rescan request.
- Reject 1,001 or more with HTTP 400 and stable code `rescan-too-large`.
- Perform the count check before testing RPC availability, preparing the RPC batch, creating fetch tasks, fetching headers, or writing matches.
- Preserve the existing `transactions-missing` validation and per-entry rescan behavior.

## Security impact

One HTTP request can no longer fan out into an attacker-selected number of Bitcoin Core operations or proportional in-memory task/response collections. Integrators with larger workloads can submit bounded chunks and receive a deterministic error when a chunk is too large.

Addresses Prem Security findings `custos_6gxxem` and `custos_1bu97vg`.

## Tests

- Added exact boundary tests proving 100 proxy calls and 1,000 rescan entries are accepted by validation.
- Added rejection tests proving 101 proxy calls and 1,001 rescan entries return the expected HTTP 400 error codes.
- Focused controller tests — 2 passed, 0 failed.
- `dotnet build NBXplorer.sln -c Release --no-restore --verbosity minimal` — succeeded with 0 errors.
- `docker compose build` and `docker compose run --rm tests` from `NBXplorer.Tests` — 100 passed, 0 failed.

## Compatibility

Single RPC requests and ordinary batches/rescans are unchanged. This intentionally introduces per-request ceilings; clients exceeding them must chunk their requests.
