### PR TITLE
Limit event responses and WebSocket subscription rules

### DIFF
--- a/NBXplorer.Tests/EventStreamLimitsTests.cs
+++ b/NBXplorer.Tests/EventStreamLimitsTests.cs
@@ -1,0 +1,32 @@
+using NBXplorer.Controllers;
+using NBXplorer.Models;
+using Xunit;
+
+namespace NBXplorer.Tests
+{
+	public class EventStreamLimitsTests
+	{
+		[Fact]
+		public void EventQueryLimitMustBeWithinBounds()
+		{
+			Assert.Equal("invalid-limit", Assert.Throws<NBXplorerException>(() => MainController.ValidateEventLimit(0)).Error.Code);
+			Assert.Equal("invalid-limit", Assert.Throws<NBXplorerException>(() => MainController.ValidateEventLimit(10_001)).Error.Code);
+
+			Assert.Equal(10_000, MainController.NormalizeEventLimit(null));
+			MainController.ValidateEventLimit(1);
+			MainController.ValidateEventLimit(10_000);
+		}
+
+		[Theory]
+		[InlineData(999, 1, true)]
+		[InlineData(1_000, 1, false)]
+		[InlineData(999, 2, false)]
+		[InlineData(0, 1_000, true)]
+		[InlineData(0, 1_001, false)]
+		[InlineData(999, int.MaxValue, false)]
+		public void WebSocketRulesHaveAPerConnectionCeiling(int existing, int added, bool expected)
+		{
+			Assert.Equal(expected, MainController.CanAppendEventRules(existing, added));
+		}
+	}
+}

--- a/NBXplorer/Controllers/MainController.cs
+++ b/NBXplorer/Controllers/MainController.cs
@@ -33,6 +33,25 @@ namespace NBXplorer.Controllers
 	[Authorize]
 	public partial class MainController : Controller
 	{
+		internal const int MaxEventsPerRequest = 10_000;
+		internal const int MaxWebSocketRules = 1_000;
+
+		internal static void ValidateEventLimit(int? limit)
+		{
+			if (limit is < 1 or > MaxEventsPerRequest)
+				throw new NBXplorerError(400, "invalid-limit", $"limit should be between 1 and {MaxEventsPerRequest}").AsException();
+		}
+		internal static int NormalizeEventLimit(int? limit)
+		{
+			ValidateEventLimit(limit);
+			return limit ?? MaxEventsPerRequest;
+		}
+
+		internal static bool CanAppendEventRules(int existingCount, int addedCount)
+		{
+			return existingCount >= 0 && addedCount >= 0 && addedCount <= MaxWebSocketRules - existingCount;
+		}
+
 		public NBXplorerNetworkProvider NetworkProvider { get; }
 		public RPCClientProvider RPCClients { get; }
 		public RepositoryProvider RepositoryProvider { get; }
@@ -482,6 +501,12 @@ namespace NBXplorer.Controllers
 						default:
 							break;
 					}
+					var addedRuleCount = rules.Count - policy.Rules.Length;
+					if (!CanAppendEventRules(policy.Rules.Length, addedRuleCount))
+					{
+						await server.Socket.CloseAsync(WebSocketCloseStatus.PolicyViolation, $"Cannot register more than {MaxWebSocketRules} event rules", cancellation);
+						break;
+					}
 					policy.Rules = rules.ToArray();
 				}
 			}
@@ -502,8 +527,7 @@ namespace NBXplorer.Controllers
 		[Route($"{CommonRoutes.BaseCryptoEndpoint}/events")]
 		public async Task<JArray> GetEvents(string cryptoCode, int lastEventId = 0, int? limit = null, bool longPolling = false, CancellationToken cancellationToken = default)
 		{
-			if (limit != null && limit.Value < 1)
-				throw new NBXplorerError(400, "invalid-limit", "limit should be more than 0").AsException();
+			limit = NormalizeEventLimit(limit);
 			var network = GetNetwork(cryptoCode, false);
 			TaskCompletionSource<bool> waitNextEvent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			Action<NewEventBase> maySetNextEvent = (NewEventBase ev) =>
@@ -538,8 +562,7 @@ namespace NBXplorer.Controllers
 		[Route($"{CommonRoutes.BaseCryptoEndpoint}/events/latest")]
 		public async Task<JArray> GetLatestEvents(string cryptoCode, int limit = 10)
 		{
-			if (limit < 1)
-				throw new NBXplorerError(400, "invalid-limit", "limit should be more than 0").AsException();
+			ValidateEventLimit(limit);
 			var network = GetNetwork(cryptoCode, false);
 			var repo = RepositoryProvider.GetRepository(network);
 			var result = await repo.GetLatestEvents(limit);


### PR DESCRIPTION
## Why

The event APIs accepted an omitted or arbitrarily large `limit`, which could make a single authenticated request retrieve an unbounded event history. WebSocket clients could also keep appending subscription rules for the lifetime of a connection, making every subsequent event evaluate an attacker-controlled, ever-growing rule list.

NBXplorer is normally deployed as a trusted internal service, so this change focuses on bounding work inside one authorized request or connection. Global concurrent-connection limits remain a deployment/server concern.

## What changed

- Normalize an omitted `GET /events` limit to 10,000 instead of querying an unbounded history.
- Reject event limits below 1 or above 10,000 with the stable `invalid-limit` 400 response.
- Apply the same upper bound to `GET /events/latest`.
- Limit each WebSocket connection to 1,000 total subscription rules.
- Close a socket with `PolicyViolation` before installing an oversized rule set.
- Use overflow-safe accounting when combining existing and newly requested rules.

## Compatibility

Normal polling, long-polling, and WebSocket behavior is unchanged within the limits. Existing clients that omit the event limit still receive up to 10,000 events. WebSocket clients can register up to 1,000 rules per connection.

## Validation

- `dotnet test NBXplorer.Tests/NBXplorer.Tests.csproj -c Release --filter FullyQualifiedName~EventStreamLimitsTests`: 7 passed.
- `dotnet build NBXplorer.sln -c Release --no-restore`: passed.
- `docker compose run --rm tests`: 104 passed, 1 transient cancellation in `CanGenerateWallet` after 69 seconds; the event long-poll and WebSocket integration tests passed.
- Isolated rerun of `CanGenerateWallet`: passed in 40 seconds.
- `git diff --check`: passed.

## Scanner finding

Addresses `custos_h31fyg`: unbounded event history retrieval and per-connection WebSocket subscription growth. This does not add a process-wide connection cap; that remains the responsibility of the trusted deployment boundary and reverse proxy/server configuration.